### PR TITLE
Uses testdox prettifier for titles

### DIFF
--- a/src/CodewarsResultPrinter.php
+++ b/src/CodewarsResultPrinter.php
@@ -20,8 +20,8 @@ use SebastianBergmann\Comparator\ComparisonFailure;
  */
 class CodewarsResultPrinter extends DefaultResultPrinter
 {
-	
-	private $prettifier;
+
+    private $prettifier;
     /**
      * @var TestSuite
      */
@@ -29,10 +29,10 @@ class CodewarsResultPrinter extends DefaultResultPrinter
     // Temporarily store failure messages so that the outputs can be written before them.
     private $failures = array();
 
-	public function __construct() {
-		parent::__construct();
-		 $this->prettifier = new \PHPUnit\Util\TestDox\NamePrettifier();
-	}
+    public function __construct() {
+        parent::__construct();
+        $this->prettifier = new \PHPUnit\Util\TestDox\NamePrettifier();
+    }
 
     /**
      * An error occurred.

--- a/src/CodewarsResultPrinter.php
+++ b/src/CodewarsResultPrinter.php
@@ -20,12 +20,19 @@ use SebastianBergmann\Comparator\ComparisonFailure;
  */
 class CodewarsResultPrinter extends DefaultResultPrinter
 {
+	
+	private $prettifier;
     /**
      * @var TestSuite
      */
     private $wrapperSuite = null;
     // Temporarily store failure messages so that the outputs can be written before them.
     private $failures = array();
+
+	public function __construct() {
+		parent::__construct();
+		 $this->prettifier = new \PHPUnit\Util\TestDox\NamePrettifier();
+	}
 
     /**
      * An error occurred.
@@ -97,6 +104,7 @@ class CodewarsResultPrinter extends DefaultResultPrinter
         if (empty($suiteName)) {
             return;
         }
+        $suiteName = $this->prettifier->prettifyTestClass($suiteName);
         $this->write(sprintf("\n<DESCRIBE::>%s\n", $suiteName));
     }
 
@@ -122,7 +130,11 @@ class CodewarsResultPrinter extends DefaultResultPrinter
      */
     public function startTest(Test $test): void
     {
-        $this->write(sprintf("\n<IT::>%s\n", $test->getName()));
+        $title = $test->getName();
+        if ($test instanceof TestCase) {
+            $title = $this->prettifier->prettifyTestCase($test);
+        }
+        $this->write(sprintf("\n<IT::>%s\n", $title));
         $this->failures = array();
     }
 


### PR DESCRIPTION
Implements #4 

Example kumite with result: [here](https://www.codewars.com/kumite/6570fc4651c2bf734c2dcb69?sel=6570fc4651c2bf734c2dcb69).

Pros:
- Understands `@testdox` annotation on test classes, test methods, and generated tests.

Cons:
- Prettifies in a default testdox way also titles which are not annotated with a custom title. As a result, existing CW test suites also will be affected (note how the `testZeroIsEven` gets prettified despite of having no annotation).
- Titles of `<DESCRIBE::>` groups of tests generated with `@dataProvider` seem to not respect the annotation (but this might be a bug of my implementation)